### PR TITLE
Template optional setting of JAVA_HOME

### DIFF
--- a/templates/wildfly.conf.erb
+++ b/templates/wildfly.conf.erb
@@ -2,8 +2,12 @@
 # not necessarily for JBoss AS itself.
 # default location: /etc/default/wildfly
 
-# Location of JDK	
+# Location of JDK
+<% if @java_home -%>
+JAVA_HOME=<%= @java_home %>
+<% else -%>
 # JAVA_HOME=/usr/lib/jvm/default-java
+<% end -%>
 
 # Location of WildFly
 JBOSS_HOME=<%= @install_dir %>/wildfly


### PR DESCRIPTION
There's a parameter called java_home in the module, which is ignored. By updating the wildfly.conf.erb template one can decide to install Java externally to the wildfly module (e.g. in another module; wildfly::install_java: false), and specify the JAVA_HOME location through this parameter.