### PR TITLE
Remove ExampleDS references

### DIFF
--- a/templates/standalone/subsystems/jboss:domain:ee:2.0.xml.erb
+++ b/templates/standalone/subsystems/jboss:domain:ee:2.0.xml.erb
@@ -16,5 +16,4 @@
                     <managed-thread-factory name="default" jndi-name="java:jboss/ee/concurrency/factory/default" context-service="default"/>
                 </managed-thread-factories>
             </concurrent>
-            <default-bindings context-service="java:jboss/ee/concurrency/context/default" datasource="java:jboss/datasources/ExampleDS" jms-connection-factory="java:jboss/DefaultJMSConnectionFactory" managed-executor-service="java:jboss/ee/concurrency/executor/default" managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default" managed-thread-factory="java:jboss/ee/concurrency/factory/default"/>
         </subsystem>

--- a/templates/standalone/subsystems/jboss:domain:ee:3.0.xml.erb
+++ b/templates/standalone/subsystems/jboss:domain:ee:3.0.xml.erb
@@ -16,5 +16,4 @@
                     <managed-scheduled-executor-service name="default" jndi-name="java:jboss/ee/concurrency/scheduler/default" context-service="default" hung-task-threshold="60000" core-threads="2" keepalive-time="3000"/>
                 </managed-scheduled-executor-services>
             </concurrent>
-            <default-bindings context-service="java:jboss/ee/concurrency/context/default" datasource="java:jboss/datasources/ExampleDS" jms-connection-factory="java:jboss/DefaultJMSConnectionFactory" managed-executor-service="java:jboss/ee/concurrency/executor/default" managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default" managed-thread-factory="java:jboss/ee/concurrency/factory/default"/>
         </subsystem>


### PR DESCRIPTION
Fixes #20 

Removed the obsolete references to the ExampleDS from domain::ee configs.